### PR TITLE
Add support of notice_only project

### DIFF
--- a/lib/hbw/config.rb
+++ b/lib/hbw/config.rb
@@ -1,0 +1,8 @@
+module HBW
+  class Config
+    def initialize
+      @notice_only_api_key = nil
+    end
+    attr_accessor :notice_only_api_key
+  end
+end


### PR DESCRIPTION
## Why
Sometimes we want to notify exception with notice_only flag to another project.

## What
Add support of `notice_only_notifier`.

When `notice_only_api_key` is set in `HBW.configure`, `notice_only_notifier` is created.
If `notice_only_notifier` exists, exception with notice_only flag is notified by `notice_only_notifier`.