### PR TITLE
Fix configuration of notice_only_notifier

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hbw (0.2.0)
+    hbw (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/hbw.rb
+++ b/lib/hbw.rb
@@ -168,7 +168,14 @@ module HBW
     end
 
     def build_notifier(api_key)
-      r = ::Honeybadger::Agent.new(::Honeybadger.config.dup)
+      r = ::Honeybadger::Agent.new
+      r.init!({
+        :root           => ::Rails.root.to_s,
+        :env            => ::Rails.env,
+        :'config.path'  => ::Rails.root.join('config', 'honeybadger.yml'),
+        :logger         => ::Honeybadger::Logging::FormattedLogger.new(::Rails.logger),
+        :framework      => :rails
+      })
       r.configure do |config|
         config.api_key = api_key
       end

--- a/lib/hbw/version.rb
+++ b/lib/hbw/version.rb
@@ -1,3 +1,3 @@
 module HBW
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
## Why
When we want to create new `Honeybadger::Agent`,  sometimes `::Honeybadger.config` is not configured yet.

## What
Use `Honeybadger::Agent#init!` instead of `::Honeybadger.config`.
