### PR TITLE
 Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ HBW.notify(
 # end
 ```
 
-### `notifce_only` option
+### `notice_only` option
 
 This option is default false.
 


### PR DESCRIPTION
Fixed typo:

`notifce_only` -> `notice_only` 