### PR TITLE
Set notice_only as tag

### DIFF
--- a/lib/hbw.rb
+++ b/lib/hbw.rb
@@ -4,6 +4,8 @@ require "hbw/config"
 module HBW
   class ArgumentError < ::ArgumentError; end
 
+  TAG = "notice_only".freeze
+
   @notice_only_notifier = nil
 
   class << self
@@ -98,6 +100,7 @@ module HBW
 
       if notice_only
         opts[:error_message] = "[Notice Only] #{error_class(exception_or_opts, opts)}: #{error_message(exception_or_opts, opts)}"
+        opts[:tags] = opts.key?(:tags) ? "#{opts[:tags]}, #{TAG}" : TAG
       end
 
       # QA, Production


### PR DESCRIPTION
## WHY

We would like to except `Notice Only` reports from integrations.
But it's too difficult to except them.

## WHAT

Set `notice_only` as a tag when the flag is enabled.